### PR TITLE
build: Configure explicit non-deprecated Gradle plugin develocity for build scans (#100428)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,12 @@
-rootProject.name = "test-gradle-plugin"
+plugins {
+    id("com.gradle.develocity") version "3.18.1"
+}
 
+develocity {
+    buildScan {
+        termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+        termsOfUseAgree = "yes"
+    }
+}
+
+rootProject.name = "test-gradle-plugin"


### PR DESCRIPTION
Closes AB#100428